### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM node:lts-alpine3.18
+# Build Stage
+FROM node:18-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci --only=production
 COPY . .
-CMD [ "npm", "start" ]
+
+# Production Stage
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app /app
+CMD ["npm", "start"]


### PR DESCRIPTION
I saw you post on LinkedIn and was caught by the missing `FROM SCRATCH` in your `Dockerfile`. Turns out it's not that easy for Node/NPM, but I didn't want to give up. I've managed to reduce the final image size of the Docker image from 259MB (`shoggomo/mg-scanner`) down to 149MB (`myscan`).

![image](https://github.com/user-attachments/assets/07bdd1f1-f7bb-4c92-89ee-e0f46ca5aa18)

This will hopefully make the container more lightweight, faster to start and less space-hungry. It was definitely fun to play around with the multi stage build process, helped to learn a lot about Docker.

Some observations while trying to run the project:
-  I believe the `.env.example` is missing a `"schedule": "some chron expression",` entry. At least I couldn't get it started without it
- It might make sense to look into alternatives to the `.env` since you can just `docker exec -it <docker-container-id> sh` and `echo $CONFIG` to get your `"telegramToken"`, I don't have an idea how to do this though so if you find out more please let me know as this is a common issue for me as well. Just wanted to make sure that you're aware of this as well, since your image can be pulled by anyone :)
- When building the Docker image and running it I kept wondering, why no config was found. Turns out locally the `.env` is in the `.dockerignore` file, excluding it in the build process. Is this on purpose?